### PR TITLE
Convert Node2Ds to Node

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 bitbrain
+Copyright (c) 2023 Zennyth
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/addons/enhanced_stat/scripts/core/status_effects/components/vfx_status_effect_component.gd
+++ b/addons/enhanced_stat/scripts/core/status_effects/components/vfx_status_effect_component.gd
@@ -3,7 +3,7 @@ class_name VfxStatusEffectComponent
 
 @export var packed_vfx: PackedScene
 
-var vfx: Node2D
+var vfx: Node
 
 func _enable() -> void:
 	vfx = packed_vfx.instantiate()

--- a/addons/enhanced_stat/scripts/core/status_effects/status_effect.gd
+++ b/addons/enhanced_stat/scripts/core/status_effects/status_effect.gd
@@ -42,7 +42,7 @@ var tick_clock: float = .0
 var initial_status_effect_components: Array[StatusEffectComponent] = []
 
 
-func is_target_valid(_target: Node2D) -> bool:
+func is_target_valid(_target: Node) -> bool:
 	return true
 
 func set_target(value) -> void:

--- a/addons/enhanced_stat/scripts/core/status_effects/status_effect_abstract.gd
+++ b/addons/enhanced_stat/scripts/core/status_effects/status_effect_abstract.gd
@@ -1,6 +1,6 @@
 extends Resource
 
-var target: Node2D:
+var target: Node:
 	set = set_target
 
 func set_target(value) -> void:

--- a/addons/enhanced_stat/scripts/core/status_effects/status_effect_applier.gd
+++ b/addons/enhanced_stat/scripts/core/status_effects/status_effect_applier.gd
@@ -4,7 +4,7 @@ class_name StatusEffectApplier
 
 @export var status_effects: Array[StatusEffect] = []
 
-func apply(target: Node2D) -> void:
+func apply(target: Node) -> void:
 	var status_effect_manager: StatusEffectManager = NodeUtils.find_node(target, StatusEffectManager)
 
 	if status_effect_manager == null or status_effects == null:
@@ -18,7 +18,7 @@ func apply(target: Node2D) -> void:
 
 
 
-func remove(target: Node2D) -> void:
+func remove(target: Node) -> void:
 	var status_effect_manager: StatusEffectManager = NodeUtils.find_node(target, StatusEffectManager)
 
 	if status_effect_manager == null or status_effects == null:


### PR DESCRIPTION
Change all instances of Node2Ds to use Node which allows the use of this addon for 3D project.